### PR TITLE
removed non-existent dependency that causes error

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "repository": "https://github.com/rebel1804/nodecg-eec-2018-lol.git",
   "private": true,
   "dependencies": {
-    "polymer": "^1.0.0",
     "polymer-cli": "^1.6.0"
   }
 }


### PR DESCRIPTION
This line I removed causes an error to be thrown whenever the bundle is installed into nodeCG